### PR TITLE
fix: Handle the error when the folder doesn't exist or can't find Chart file

### DIFF
--- a/src/__tests__/test-cli-args.ts
+++ b/src/__tests__/test-cli-args.ts
@@ -1,4 +1,5 @@
 import { IArgs, parseInputParameters } from "../cli-args";
+import fs = require("fs");
 
 describe("test command", () => {
   describe("check required input directory", () => {
@@ -12,31 +13,56 @@ describe("test command", () => {
       mockProcessExit.mockRestore();
     });
 
+    test("handles error when directory is invalid", () => {
+      const inputArgs = ["test", "/not-valid-folder"];
+      //@ts-ignore
+      const mockProcessExit = jest.spyOn(process, "exit").mockImplementation(code => {});
+
+      parseInputParameters(inputArgs);
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      mockProcessExit.mockRestore();
+    });
+
     test("handles dot as input", () => {
-      const inputArgs = ["test", "."];
+      const path = ".";
+      const chartPath = `${path}/Chart.yaml`;
+      fs.writeFileSync(chartPath, "");
+      const inputArgs = ["test", path];
 
       const parsedArgs = parseInputParameters(inputArgs);
 
       expect(parsedArgs.inputDirectory).toBe(".");
       expect(parsedArgs.debug).toBe(false);
+
+      fs.unlinkSync(chartPath);
     });
 
     test("handle absolute path as input", () => {
-      const inputArgs = ["test", "/some/other/path"];
+      const path = "/tmp";
+      const chartPath = `${path}/Chart.yaml`;
+      fs.writeFileSync(chartPath, "");
+      const inputArgs = ["test", path];
       const parsedArgs = parseInputParameters(inputArgs);
 
-      expect(parsedArgs.inputDirectory).toBe("/some/other/path");
+      expect(parsedArgs.inputDirectory).toBe(path);
 
       expect(parsedArgs.debug).toBe(false);
+
+      fs.unlinkSync(chartPath);
     });
 
     test("handle relative path as input", () => {
-      const inputArgs = ["test", "~/other/path"];
+      const path = "./src";
+      const chartPath = `${path}/Chart.yaml`;
+      fs.writeFileSync(chartPath, "");
+      const inputArgs = ["test", path];
 
       const parsedArgs = parseInputParameters(inputArgs);
 
-      expect(parsedArgs.inputDirectory).toBe("~/other/path");
+      expect(parsedArgs.inputDirectory).toBe(path);
       expect(parsedArgs.debug).toBe(false);
+
+      fs.unlinkSync(chartPath);
     });
   });
 });
@@ -52,18 +78,30 @@ test("yargs causes process exit if no args", () => {
 });
 
 test("handles debug flag", () => {
-  const inputArgs = ["test", ".", "--debug"];
-  const parsedArgs: IArgs = parseInputParameters(inputArgs);
-  expect(parsedArgs.inputDirectory).toBe(".");
+  const path = ".";
+  const chartPath = `${path}/Chart.yaml`;
+  fs.writeFileSync(chartPath, "");
+  const inputArgs = ["test", path, "--debug"];
+
+  const parsedArgs = parseInputParameters(inputArgs);
+
+  expect(parsedArgs.inputDirectory).toBe(path);
   expect(parsedArgs.debug).toBe(true);
+
+  fs.unlinkSync(chartPath);
 });
 
 describe("Handle json flag", () => {
   test("option --json", () => {
-    const inputArgs = ["test", ".", "--json"];
+    const path = ".";
+    const chartPath = `${path}/Chart.yaml`;
+    fs.writeFileSync(chartPath, "");
+    const inputArgs = ["test", path, "--json"];
 
     const parsedArgs: IArgs = parseInputParameters(inputArgs);
 
     expect(parsedArgs.json).toBeTruthy();
+
+    fs.unlinkSync(chartPath);
   });
 });

--- a/src/__tests__/test-main-runCommand.ts
+++ b/src/__tests__/test-main-runCommand.ts
@@ -1,7 +1,6 @@
 import { IExecCommandResult } from "../main";
 import { ExecException } from "child_process";
 import fs from "fs";
-import { async } from "q";
 
 beforeEach(() => {
   jest.resetModules();

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,4 +1,5 @@
 const yargs = require("yargs");
+const fs = require("fs");
 
 interface IArgs {
   inputDirectory: string;
@@ -44,6 +45,7 @@ function parseInputParameters(inputArgs): IArgs {
     .options(getOptions())
     .hide("notest")
     .demandCommand(2)
+    .check(isValidChartDirectory)
     .example("$0 test . --output=snyk-out.json").argv;
 
   returnObj.inputDirectory = argv.chartDirectory;
@@ -66,5 +68,12 @@ function parseInputParameters(inputArgs): IArgs {
 
   return returnObj;
 }
+
+const isValidChartDirectory = argv => {
+  if (fs.existsSync(`${argv.chartDirectory}/Chart.yaml`) || fs.existsSync(`${argv.chartDirectory}/Chart.yml`)) return true;
+
+  const msgError = `Invalid Chart directory. ${argv.chartDirectory} is not a valid path for a Chart!`;
+  throw new Error(msgError);
+};
 
 export { IArgs, parseInputParameters };


### PR DESCRIPTION
**BugFix:**
- handle error when the chart directory is invalid;
- handle error when could not find a `Chart.yaml` or `Chart.yml`