### PR TITLE
Fix/allow pass options to helm template call

### DIFF
--- a/src/__tests__/test-cli-args.ts
+++ b/src/__tests__/test-cli-args.ts
@@ -7,7 +7,7 @@ let consoleMock;
 beforeEach(() => {
   //@ts-ignore
   mockProcessExit = jest.spyOn(process, "exit").mockImplementation(code => {});
-  consoleMock = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+  consoleMock = jest.spyOn(console, "error").mockImplementation(jest.fn());
 });
 
 afterEach(() => {
@@ -98,7 +98,7 @@ describe("test command", () => {
   describe("check required input directory", () => {
     test("process exit if there is no <chart-directory> required arg", () => {
       const inputArgs = ["test"];
-      
+
       parseInputParameters(inputArgs);
 
       expect(mockProcessExit).toHaveBeenCalledWith(1);

--- a/src/__tests__/test-main-runCommand.ts
+++ b/src/__tests__/test-main-runCommand.ts
@@ -61,8 +61,6 @@ test("validate stderr captured", async () => {
 });
 
 describe("Assemble helm template command", () => {
-  // IArgs -> String
-  // produce the `helm template` command with or without options
   test("command without options for helm template", () => {
     const options = { inputDirectory: "." } as IArgs;
     const expectedCommand = "helm template .";

--- a/src/__tests__/test-main-runCommand.ts
+++ b/src/__tests__/test-main-runCommand.ts
@@ -1,6 +1,7 @@
 import { IExecCommandResult } from "../main";
 import { ExecException } from "child_process";
 import fs from "fs";
+import { IArgs } from "../cli-args";
 
 beforeEach(() => {
   jest.resetModules();
@@ -57,6 +58,37 @@ test("validate stderr captured", async () => {
   expect(res.exitCode).toBe(0);
   expect(res.stdout.trim()).toBe("");
   expect(res.stderr.trim()).toBe("error");
+});
+
+describe("Assemble helm template command", () => {
+  // IArgs -> String
+  // produce the `helm template` command with or without options
+  test("command without options for helm template", () => {
+    const options = { inputDirectory: "." } as IArgs;
+    const expectedCommand = "helm template .";
+
+    const command = mainModule.assembleHelmTemplateCommand(options);
+
+    expect(command).toEqual(expectedCommand);
+  });
+
+  test("command with empty options for helm template", () => {
+    const options = { inputDirectory: "/tmp", helmTemplateOptions: "" } as IArgs;
+    const expectedCommand = "helm template /tmp";
+
+    const command = mainModule.assembleHelmTemplateCommand(options);
+
+    expect(command).toEqual(expectedCommand);
+  });
+
+  test("command with no-empty options for helm template", () => {
+    const options = { inputDirectory: "/tmp", helmTemplateOptions: "--set stringArray" } as IArgs;
+    const expectedCommand = "helm template /tmp --set stringArray";
+
+    const command = mainModule.assembleHelmTemplateCommand(options);
+
+    expect(command).toEqual(expectedCommand);
+  });
 });
 
 describe("Assemble Snyk command", () => {

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -7,9 +7,32 @@ interface IArgs {
   json: boolean;
   notest: boolean;
   debug: boolean;
+  helmTemplateOptions: string;
 }
 
-function getOptions() {
+const parseInputParameters = (inputArgs): IArgs => {
+  const scriptName = "helm snyk";
+  const usageMsg = "Usage: $0 <command>";
+  const testCommandUsage = "test <chart-directory> [options]";
+  const testCommandDescription = "Check images in your charts for vulnerabilities";
+  const scriptExample = "$0 test . --output=snyk-out.json";
+  const argv = yargs(inputArgs)
+    .version()
+    .scriptName(scriptName)
+    .usage(usageMsg)
+    .command(testCommandUsage, testCommandDescription)
+    .help("help")
+    .alias("help", "h")
+    .options(optionsConfiguration())
+    .hide("notest")
+    .demandCommand(2)
+    .check(isValidChartDirectory)
+    .example(scriptExample).argv;
+
+  return parseOptions(argv);
+};
+
+const optionsConfiguration = () => {
   return {
     output: {
       type: "string"
@@ -22,58 +45,84 @@ function getOptions() {
     },
     notest: {
       type: "boolean"
+    },
+    set: {
+      type: "string",
+      describe:
+        "(helm template option) --set='stringArray' set values on the command line (can specify multiple or separate values with commas: --set='key1=val1,key2=val2')"
+    },
+    setFile: {
+      type: "string",
+      describe:
+        "(helm template option) --set='stringArray' set values on the command line (can specify multiple or separate values with commas: --set-file='key1=val1,key2=val2')"
+    },
+    setString: {
+      type: "string",
+      describe:
+        "(helm template option) --set-string='stringArray' set STRING values on the command line (can specify multiple or separate values with commas: --set-string='key1=val1,key2=val2')"
+    },
+    values: {
+      type: "string",
+      describe: "(helm template option) --values='file' specify values in a YAML file (can specify multiple --values='file1,file2')"
     }
   };
-}
-
-function parseInputParameters(inputArgs): IArgs {
-  const returnObj = {
-    inputDirectory: "",
-    output: "",
-    json: false,
-    notest: false,
-    debug: false
-  } as IArgs;
-
-  const argv = yargs(inputArgs)
-    .version()
-    .scriptName("helm snyk")
-    .usage("Usage: $0 <command>")
-    .command("test <chart-directory> [options]", "Check images in your charts for vulnerabilities")
-    .help("help")
-    .alias("help", "h")
-    .options(getOptions())
-    .hide("notest")
-    .demandCommand(2)
-    .check(isValidChartDirectory)
-    .example("$0 test . --output=snyk-out.json").argv;
-
-  returnObj.inputDirectory = argv.chartDirectory;
-
-  if (argv.json) {
-    returnObj.json = argv.json;
-  }
-
-  if (argv.output) {
-    returnObj.output = argv.output;
-  }
-
-  if (argv.notest) {
-    returnObj.notest = argv.notest;
-  }
-
-  if (argv.debug) {
-    returnObj.debug = argv.debug;
-  }
-
-  return returnObj;
-}
+};
 
 const isValidChartDirectory = argv => {
   if (fs.existsSync(`${argv.chartDirectory}/Chart.yaml`) || fs.existsSync(`${argv.chartDirectory}/Chart.yml`)) return true;
 
   const msgError = `Invalid Chart directory. ${argv.chartDirectory} is not a valid path for a Chart!`;
   throw new Error(msgError);
+};
+
+const parseOptions = (argv: any) => {
+  const options = {
+    inputDirectory: "",
+    output: "",
+    json: false,
+    notest: false,
+    debug: false,
+    helmTemplateOptions: ""
+  } as IArgs;
+
+  options.inputDirectory = argv.chartDirectory;
+  if (argv.json) {
+    options.json = argv.json;
+  }
+  if (argv.output) {
+    options.output = argv.output;
+  }
+  if (argv.notest) {
+    options.notest = argv.notest;
+  }
+  if (argv.debug) {
+    options.debug = argv.debug;
+  }
+  options.helmTemplateOptions = parseHelmTemplateOptions(argv);
+
+  return options;
+};
+
+const parseHelmTemplateOptions = (argv: any) => {
+  const helmTemplateOptions: string[] = [];
+
+  if (argv.set) {
+    helmTemplateOptions.push(`--set ${argv.set}`);
+  }
+  if (argv.setFile) {
+    helmTemplateOptions.push(`--set-file ${argv.setFile}`);
+  }
+  if (argv.setString) {
+    helmTemplateOptions.push(`--set-string ${argv.setString}`);
+  }
+  if (argv.values) {
+    const values: string[] = [];
+    for (const value of argv.values.split(",")) {
+      values.push(`--values ${value}`);
+    }
+    helmTemplateOptions.push(values.join(" "));
+  }
+  return helmTemplateOptions.join(" ");
 };
 
 export { IArgs, parseInputParameters };

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,7 +95,7 @@ async function runSnykTestWithDocker(snykToken: string, snykCLIImageName: string
   };
 
   const createOptions = {
-    env: [`SNYK_TOKEN=${snykToken}`, "ENV_FLAGS=disableSuggestions=true"],
+    env: [`SNYK_TOKEN=${snykToken}`],
     Binds: ["/var/run/docker.sock:/var/run/docker.sock"],
     Tty: false
   };
@@ -118,19 +118,14 @@ async function runSnykTestWithDocker(snykToken: string, snykCLIImageName: string
   });
 }
 
-export function assembleSnykCommand(imageName: string, options: any) {
+export const assembleSnykCommand = (imageName: string, options: any) => {
   let command = `snyk test --docker ${imageName}`;
   if (options.json) command = command + " --json";
   if (options.debug) console.debug(command);
   if (options.debug) console.debug(options);
 
   return command;
-}
-
-function loadMultiDocYamlFromString(strMultiDocYaml: string) {
-  const docs = yaml.safeLoadAll(strMultiDocYaml);
-  return docs;
-}
+};
 
 export function isValidImageName(imageName: string): boolean {
   // This regex is from https://stackoverflow.com/questions/39671641/regex-to-parse-docker-tag posted 2016-Sept-24, falling under MIT license
@@ -186,7 +181,8 @@ function getHelmChartLabelForOutput(helmChartDirectory: string): string {
 }
 
 export async function mainWithParams(args: IArgs, snykToken: string) {
-  const helmCommand = `helm template ${args.inputDirectory}`;
+  const helmCommand = assembleHelmTemplateCommand(args);
+  if (args.debug) console.debug("helm template command: ", helmCommand);
   const helmCommandResObj: IExecCommandResult = await runCommand(helmCommand);
   const renderedTemplates = helmCommandResObj.stdout;
 
@@ -222,7 +218,14 @@ export async function mainWithParams(args: IArgs, snykToken: string) {
   return allOutputData;
 }
 
-export function handleResult(helmChartLabel, results: SnykResult[], options) {
+export const assembleHelmTemplateCommand = (options: IArgs) => {
+  let cmd = `helm template ${options.inputDirectory}`;
+  if (options.helmTemplateOptions) cmd = `${cmd} ${options.helmTemplateOptions}`;
+
+  return cmd;
+};
+
+export const handleResult = (helmChartLabel, results: SnykResult[], options) => {
   let output;
   if (options.json) {
     output = {
@@ -238,25 +241,25 @@ export function handleResult(helmChartLabel, results: SnykResult[], options) {
   }
 
   return output;
-}
+};
 
-function chopTheAdditionalSuggestions(result: SnykResult) {
+const chopTheAdditionalSuggestions = (result: SnykResult) => {
   const preOutput = result.result.split("\n");
   const NUMBER_OF_LINES_TO_BE_CUT = 7;
   const NUMBER_OF_LINES_TO_BE_KEEP = preOutput.length - NUMBER_OF_LINES_TO_BE_CUT;
   const trimmedOutput = preOutput.slice(0, NUMBER_OF_LINES_TO_BE_KEEP);
 
   return trimmedOutput.join("\n");
-}
+};
 
-export function handleOutput(output, options) {
+export const handleOutput = (output, options) => {
   if (options.json) output = JSON.stringify(output, null, 2);
   if (options.output) {
     fs.writeFileSync(options.output, output);
   } else {
     console.log(output);
   }
-}
+};
 
 async function main() {
   const snykToken: string = process.env.SNYK_TOKEN ? process.env.SNYK_TOKEN : "";


### PR DESCRIPTION
BugFix:
- Allow pass options to internal command call `helm template`
- Handle error when it's missing dependencies for `helm template` command