### PR TITLE
add version check to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,42 @@ jobs:
             npm run build
             npm test
 
+  version_check:
+    docker:
+      - image: circleci/node:lts
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Version Check for Semantic Release
+          command: |
+            npm install  # required here for semantic-release install
+            npx semantic-release --dry-run --branch ${CIRCLE_BRANCH} > sem-rel-dry-run.txt
+            echo "semantic-release dry run output:"
+            cat sem-rel-dry-run.txt
+            echo "branch: ${CIRCLE_BRANCH}"
+
+            if grep "The next release version is" sem-rel-dry-run.txt
+            then
+              dry_run_version=$(cat sem-rel-dry-run.txt | grep "The next release version is" | sed -n -e 's/^.*is //p')
+              echo "semantic-release dry run version: ${dry_run_version}"
+              plugin_file_version=$(cat plugin.yaml | grep version | sed -n -e 's/^\(version:\) \"\(.*\)\"/\2/p')
+              echo "Plugin file version: ${plugin_file_version}"
+              echo "Will fail if ${dry_run_version} does not equal ${plugin_file_version}"
+              # Fail if the "next" version from the dry-run is not equal to the version specified in the plugin.yaml
+              test $dry_run_version = $plugin_file_version
+            elif grep "a new version won’t be published" sem-rel-dry-run.txt
+            then
+              echo "version check passes"
+            elif grep "There are no relevant changes, so no new version is released" sem-rel-dry-run.txt
+            then
+              echo "version check passes"
+            else
+              # failing here this will help us detect new/changed/unanticipated log messages/scenarios from semantic-release
+              echo "unknown semantic-release dry-run state - failing"
+              exit 1
+            fi
+
   release:
     docker:
       - image: circleci/node:lts
@@ -42,9 +78,14 @@ workflows:
   build_test_release:
     jobs:
       - build_and_test
+      - version_check:
+          filters:
+            branches:
+              only: master
       - release:
           context: nodejs-lib-release
           requires:
+            - version_check
             - build_and_test
           filters:
             branches:


### PR DESCRIPTION
Add version check to CircleCI so that we don't create a release (with semantic-release) with an incorrect version in the plugin.yaml