### PR TITLE
chore: add nodejs-lib-release to the version_check job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ workflows:
     jobs:
       - build_and_test
       - version_check:
+          context: nodejs-lib-release
           filters:
             branches:
               only: master


### PR DESCRIPTION
add nodejs-lib-release to the version_check job 
Re BDE-40
